### PR TITLE
Add class factories

### DIFF
--- a/src/Toolbar.Control.js
+++ b/src/Toolbar.Control.js
@@ -25,3 +25,7 @@ L.Control.Toolbar = L.Control.extend({
 		return L.DomUtil.create('div', '');
 	}
 });
+
+L.toolbar.control = function(options) {
+    return new L.Toolbar.Control(options);
+};

--- a/src/Toolbar.Popup.js
+++ b/src/Toolbar.Popup.js
@@ -74,3 +74,7 @@ L.Toolbar.Popup = L.Toolbar.extend({
 		container.style.marginTop = (-anchor.y) + 'px';
 	}
 });
+
+L.toolbar.popup = function(options) {
+    return new L.Toolbar.Popup(options);
+};

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -85,3 +85,5 @@ L.Toolbar = L.Class.extend({
 		return depth;
 	}
 });
+
+L.toolbar = {};

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -85,3 +85,7 @@ L.Toolbar = L.Class.extend({
 		return depth;
 	}
 });
+
+L.toolbar = function(options) {
+    return new L.Toolbar(options);
+};

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -85,7 +85,3 @@ L.Toolbar = L.Class.extend({
 		return depth;
 	}
 });
-
-L.toolbar = function(options) {
-    return new L.Toolbar(options);
-};

--- a/src/ToolbarAction.js
+++ b/src/ToolbarAction.js
@@ -9,7 +9,7 @@ L.ToolbarAction = L.Handler.extend({
 			className: '',
 			tooltip: ''
 		},
-		subToolbar: new L.Toolbar()
+		subToolbar: L.toolbar()
 	},
 
 	initialize: function(options) {
@@ -67,7 +67,7 @@ L.ToolbarAction = L.Handler.extend({
 			/* Make a copy of args so as not to pollute the args array used by other actions. */
 			args = [].slice.call(args);
 			args.push(this);
-			
+
 			subToolbar.addTo.apply(subToolbar, args);
 			subToolbar.appendToContainer(container);
 

--- a/src/ToolbarAction.js
+++ b/src/ToolbarAction.js
@@ -9,7 +9,7 @@ L.ToolbarAction = L.Handler.extend({
 			className: '',
 			tooltip: ''
 		},
-		subToolbar: L.Toolbar()
+		subToolbar: new L.Toolbar()
 	},
 
 	initialize: function(options) {

--- a/src/ToolbarAction.js
+++ b/src/ToolbarAction.js
@@ -9,7 +9,7 @@ L.ToolbarAction = L.Handler.extend({
 			className: '',
 			tooltip: ''
 		},
-		subToolbar: L.toolbar()
+		subToolbar: L.Toolbar()
 	},
 
 	initialize: function(options) {

--- a/test/src/ToolbarControlSpec.js
+++ b/test/src/ToolbarControlSpec.js
@@ -20,3 +20,12 @@ describe("L.Toolbar.Control", function() {
 		});
 	});
 });
+
+describe("L.toolbar.control", function() {
+    describe("class factory", function() {
+        it("creates L.Toolbar.Control instance", function() {
+            var options = {position: 'bottomleft'};
+            expect(L.toolbar.control(options)).to.eql(new L.Toolbar.Control(options));
+        });
+    });
+});

--- a/test/src/ToolbarPopupSpec.js
+++ b/test/src/ToolbarPopupSpec.js
@@ -54,3 +54,12 @@ describe("L.Toolbar.Popup", function() {
 		});
 	});
 });
+
+describe("L.toolbar.popup", function() {
+    describe("class factory", function() {
+        it("creates L.Toolbar.Popup instance", function() {
+            var options = {position: 'bottomleft'};
+            expect(L.toolbar.popup(options)).to.eql(new L.Toolbar.Popup(options));
+        });
+    });
+});

--- a/test/src/ToolbarSpec.js
+++ b/test/src/ToolbarSpec.js
@@ -77,12 +77,3 @@ describe("L.Toolbar", function() {
 	});
 
 });
-
-describe("L.toolbar", function() {
-    describe("class factory", function() {
-        it("creates L.Toolbar instance", function() {
-            var options = {actions: []};
-            expect(L.toolbar(options)).to.eql(new L.Toolbar(options));
-        });
-    });
-});

--- a/test/src/ToolbarSpec.js
+++ b/test/src/ToolbarSpec.js
@@ -75,4 +75,14 @@ describe("L.Toolbar", function() {
 			expect(subToolbar._calculateDepth()).to.equal(1);
 		});
 	});
+
+});
+
+describe("L.toolbar", function() {
+    describe("class factory", function() {
+        it("creates L.Toolbar instance", function() {
+            var options = {actions: []};
+            expect(L.toolbar(options)).to.eql(new L.Toolbar(options));
+        });
+    });
 });

--- a/test/src/ToolbarSpec.js
+++ b/test/src/ToolbarSpec.js
@@ -75,5 +75,4 @@ describe("L.Toolbar", function() {
 			expect(subToolbar._calculateDepth()).to.equal(1);
 		});
 	});
-
 });


### PR DESCRIPTION
This PR is a starting point for adding class factories as mentioned in https://github.com/Leaflet/Leaflet.toolbar/issues/12. I'd love to get your feedback on this.

For instance, you can now do either `new L.Toolbar(options)` or `L.toolbar(options)`. The latter is Leaflet's preferred approach.

I've added the class factories, as well as specs to test them. I believe the specs and lints still pass.

If you approve of the changes I've made so far, I can go ahead and add class factories and specs for other classes too.