### PR TITLE
Fix spaces that makes Grunt errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,9 +145,9 @@ module.exports = function(grunt) {
 
         'gh-pages': {
             src: [
-                'dist/**', 
-                'examples/**', 
-                'node_modules/leaflet/**', 
+                'dist/**',
+                'examples/**',
+                'node_modules/leaflet/**',
                 'node_modules/leaflet-draw/**'
             ]
         }


### PR DESCRIPTION
When I run grunt, I got linting errors:

```
Linting Gruntfile.js ...ERROR
[L148:C27] W102: Trailing whitespace.
                'dist/**', 
Linting Gruntfile.js ...ERROR
[L149:C31] W102: Trailing whitespace.
                'examples/**', 
Linting Gruntfile.js ...ERROR
[L150:C43] W102: Trailing whitespace.
                'node_modules/leaflet/**', 
```

Side note: what about switching to eslint, like Leaflet itself?