### PR TITLE
Reusable Control container

### DIFF
--- a/src/Toolbar.Control.js
+++ b/src/Toolbar.Control.js
@@ -26,6 +26,9 @@ L.Toolbar.Control = L.Toolbar.extend({
 
 L.Control.Toolbar = L.Control.extend({
 	onAdd: function() {
+        if(this._container) {
+            return this._container;
+        }
 		return L.DomUtil.create('div', '');
 	}
 });

--- a/src/ToolbarAction.js
+++ b/src/ToolbarAction.js
@@ -44,6 +44,9 @@ L.ToolbarAction = L.Handler.extend({
 		this._link.innerHTML = iconOptions.html;
 		this._link.setAttribute('href', '#');
 		this._link.setAttribute('title', iconOptions.tooltip);
+        if(iconOptions.id) {
+            this._link.setAttribute('id', iconOptions.id);
+        }
 
 		L.DomUtil.addClass(this._link, this.constructor.baseClass);
 		if (iconOptions.className) {

--- a/test/src/ReusableControlSpec.js
+++ b/test/src/ReusableControlSpec.js
@@ -28,14 +28,14 @@ describe("Reusable Controls", function() {
         }),
         click = function (el){
             var ev = document.createEvent("MouseEvent");
-                 ev.initMouseEvent(
+            ev.initMouseEvent(
                      "click",
                      true /* bubble */, true /* cancelable */,
                      window, null,
                      0, 0, 0, 0, /* coordinates */
                      false, false, false, false, /* modifier keys */
                      0 /*left*/, null
-                );
+            );
             el.dispatchEvent(ev);
         };
 

--- a/test/src/ReusableControlSpec.js
+++ b/test/src/ReusableControlSpec.js
@@ -1,0 +1,72 @@
+describe("Reusable Controls", function() {
+    var map,
+        toolbar,
+        startpos = "topright",
+        ToolbarControl = L.Toolbar.Control.extend({
+            switchPosition: function () {
+                var pos = {
+                    topright: "bottomleft",
+                    bottomleft: "topright"
+                };
+
+                var control = this._control;
+                var newpos = pos[control.getPosition()];
+                control.setPosition(newpos);
+            }
+        }),
+        ToolbarAction = L.ToolbarAction.extend({
+            options: {
+                toolbarIcon: {
+                    id: 'move-toolbar-icon',
+                    html: '&#10561;',
+                    tooltip: 'move toolbar to another corner'
+                }
+            },
+            addHooks: function () {
+                this.toolbar.switchPosition();
+            }
+        });
+
+    beforeEach(function() {
+        var container = L.DomUtil.create('div');
+        container.setAttribute('id', 'map-container');
+        map = new L.Map(container).setView([41.7896,-87.5996], 15);
+        toolbar = new ToolbarControl({
+            position: startpos,
+            actions: [ToolbarAction]
+        }).addTo(map);
+
+        document.body.insertAdjacentElement('afterbegin', container);
+    });
+
+    afterEach(function() {
+        document.body.removeChild(document.getElementById('map-container'));
+    });
+
+    describe("#onAdd", function() {
+        it("Adds the toolbar to the map.", function() {
+            expect(map.hasLayer(toolbar)).to.equal(true);
+        });
+        it("Is in start position.", function () {
+            expect(toolbar._control.getPosition()).to.equal(startpos);
+        });
+    });
+
+    describe("#onClick", function() {
+        it("is clicked via HTMLElement.click.", function() {
+            var icon = L.DomUtil.get('move-toolbar-icon');
+            expect(icon.click).to.be.an.instanceof(Function);
+            expect(toolbar._control.getPosition()).to.equal(startpos);
+            icon.click();
+            expect(toolbar._control.getPosition()).not.to.equal(startpos);
+            expect(toolbar._control.getPosition()).to.equal("bottomleft");
+        });
+    });
+
+    describe("#onRemove", function() {
+        it("Removes the toolbar from the map", function() {
+            map.removeLayer(toolbar);
+            expect(map.hasLayer(toolbar)).to.equal(false);
+        });
+    });
+});

--- a/test/src/ReusableControlSpec.js
+++ b/test/src/ReusableControlSpec.js
@@ -25,7 +25,19 @@ describe("Reusable Controls", function() {
             addHooks: function () {
                 this.toolbar.switchPosition();
             }
-        });
+        }),
+        click = function (el){
+            var ev = document.createEvent("MouseEvent");
+                 ev.initMouseEvent(
+                     "click",
+                     true /* bubble */, true /* cancelable */,
+                     window, null,
+                     0, 0, 0, 0, /* coordinates */
+                     false, false, false, false, /* modifier keys */
+                     0 /*left*/, null
+                );
+            el.dispatchEvent(ev);
+        };
 
     beforeEach(function() {
         var container = L.DomUtil.create('div');
@@ -54,10 +66,16 @@ describe("Reusable Controls", function() {
 
     describe("#onClick", function() {
         it("is clicked via HTMLElement.click.", function() {
-            var icon = L.DomUtil.get('move-toolbar-icon');
-            expect(icon.click).to.be.an.instanceof(Function);
             expect(toolbar._control.getPosition()).to.equal(startpos);
-            icon.click();
+            var icon = L.DomUtil.get('move-toolbar-icon');
+            // PhantomJS version <2 ?
+            if(icon.click) {
+                expect(icon.click).to.be.an.instanceof(Function);
+                icon.click();
+            }
+            else {
+                click(icon);
+            }
             expect(toolbar._control.getPosition()).not.to.equal(startpos);
             expect(toolbar._control.getPosition()).to.equal("bottomleft");
         });


### PR DESCRIPTION
- add the possibility to give an ToolbarAction '_link'-element an id …attribute
- create the control container only once
- add a test

Unfortunatly the test does not reproduce the problem. In the browser
the toolbar disapears without this fix.