### PR TITLE
Popup width growth problem

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -64,7 +64,6 @@ L.Toolbar2.Popup = L.Toolbar2.extend({
 			if (icons[i].parentNode.parentNode === toolbar) {
 				buttonHeights.push(parseInt(L.DomUtil.getStyle(icons[i], 'height'), 10));
 				toolbarWidth += Math.ceil(parseFloat(L.DomUtil.getStyle(icons[i], 'width')));
-				toolbarWidth += Math.ceil(parseFloat(L.DomUtil.getStyle(icons[i], 'border-right-width')));
 			}
 		}
 		toolbar.style.width = toolbarWidth + 'px';
@@ -73,6 +72,7 @@ L.Toolbar2.Popup = L.Toolbar2.extend({
 		this._tipContainer = L.DomUtil.create('div', 'leaflet-toolbar-tip-container', container);
 		this._tipContainer.style.width = toolbarWidth +
 			Math.ceil(parseFloat(L.DomUtil.getStyle(toolbar, 'border-left-width'))) +
+            Math.ceil(parseFloat(L.DomUtil.getStyle(toolbar, 'border-right-width'))) +
 			'px';
 
 		this._tip = L.DomUtil.create('div', 'leaflet-toolbar-tip', this._tipContainer);


### PR DESCRIPTION
Hi

The toolbar popup is growing too much

<img width="287" alt="Captura de ecrã 2022-04-26, às 18 53 58" src="https://user-images.githubusercontent.com/50747790/165369044-9961566a-3f91-4553-a5db-3a59a9023cee.png">
<img width="186" alt="Captura de ecrã 2022-04-26, às 19 05 03" src="https://user-images.githubusercontent.com/50747790/165369054-6b273963-f20d-4bc3-8397-757dfee399f1.png">


Moving the border-right-width value to outside of the loop fixes the problem
