### PR TITLE
Sub toolbar overlap problem

### DIFF
--- a/src/Toolbar.less
+++ b/src/Toolbar.less
@@ -156,6 +156,8 @@
 
 		padding-left: 0;
 
+        z-index: 2;
+
 		> li > .leaflet-toolbar-icon {
 			position: relative;
 			float: left;


### PR DESCRIPTION
Hi

The leaflet-toolbar-tip-container div overlaps the first item of every sub toolbar and does not allow clicks in the overlapped area

<img width="291" alt="Captura de ecrã 2022-04-26, às 18 20 33" src="https://user-images.githubusercontent.com/50747790/165369435-ffa140fc-66c1-4762-aa3e-ed94c142ba00.png">

A simple z-index 2 on leaflet-toolbar-1 solves the problem

